### PR TITLE
Allow provisioning private loadbalancers by disabling EIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_context_name"></a> [context\_name](#input\_context\_name) | Short descriptive, readable label of the project you are working on. Is utilized as a part of resource names. | `string` | n/a | yes |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet where the elastic load balancer will be created. | `string` | n/a | yes |
-| <a name="input_bandwidth"></a> [bandwidth](#input\_bandwidth) | The bandwidth size. The value ranges from 1 to 1000 Mbit/s. | `number` | `300` | no |
+| <a name="input_bandwidth"></a> [bandwidth](#input\_bandwidth) | The EIP bandwidth size. The value for a public loadbalancer ranges from 1 to 1000 Mbit/s. 0 disables the EIP, making the loadbalancer private. | `number` | `100` | no |
 | <a name="input_stage_name"></a> [stage\_name](#input\_stage\_name) | Utilized to distinguish separate, but mostly equal environments within the same project. Usually dev, test, qa, prod. | `string` | `"dev"` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_context_name"></a> [context\_name](#input\_context\_name) | Short descriptive, readable label of the project you are working on. Is utilized as a part of resource names. | `string` | n/a | yes |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet where the elastic load balancer will be created. | `string` | n/a | yes |
-| <a name="input_bandwidth"></a> [bandwidth](#input\_bandwidth) | The EIP bandwidth size. The value for a public loadbalancer ranges from 1 to 1000 Mbit/s. 0 disables the EIP, making the loadbalancer private. | `number` | `100` | no |
+| <a name="input_bandwidth"></a> [bandwidth](#input\_bandwidth) | The EIP bandwidth size. The value for a public loadbalancer ranges from 1 to 1000 (Mbit/s). 0 disables the EIP, making the loadbalancer private. | `number` | `100` | no |
 | <a name="input_stage_name"></a> [stage\_name](#input\_stage\_name) | Utilized to distinguish separate, but mostly equal environments within the same project. Usually dev, test, qa, prod. | `string` | `"dev"` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ resource "opentelekomcloud_lb_loadbalancer_v2" "elb" {
 }
 
 resource "opentelekomcloud_vpc_eip_v1" "ingress_eip" {
+  count = var.bandwidth == 0 ? 0 : 1
   bandwidth {
     charge_mode = "traffic"
     name        = "${var.stage_name}-${var.context_name}-ingress-bandwidth"
@@ -15,16 +16,4 @@ resource "opentelekomcloud_vpc_eip_v1" "ingress_eip" {
     type    = "5_bgp"
     port_id = opentelekomcloud_lb_loadbalancer_v2.elb.vip_port_id
   }
-}
-
-output "elb_id" {
-  value = opentelekomcloud_lb_loadbalancer_v2.elb.id
-}
-
-output "elb_private_ip" {
-  value = opentelekomcloud_lb_loadbalancer_v2.elb.vip_address
-}
-
-output "elb_public_ip" {
-  value = opentelekomcloud_vpc_eip_v1.ingress_eip.publicip[0].ip_address
 }

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,11 @@
+output "elb_id" {
+  value = opentelekomcloud_lb_loadbalancer_v2.elb.id
+}
+
+output "elb_private_ip" {
+  value = opentelekomcloud_lb_loadbalancer_v2.elb.vip_address
+}
+
+output "elb_public_ip" {
+  value = try(opentelekomcloud_vpc_eip_v1.ingress_eip[0].publicip[0].ip_address, null)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -3,16 +3,19 @@ variable "stage_name" {
   type        = string
   description = "Utilized to distinguish separate, but mostly equal environments within the same project. Usually dev, test, qa, prod."
 }
+
 variable "context_name" {
   type        = string
   description = "Short descriptive, readable label of the project you are working on. Is utilized as a part of resource names."
 }
+
 variable "bandwidth" {
   type        = number
-  default     = 300
-  description = "The bandwidth size. The value ranges from 1 to 1000 Mbit/s."
+  default     = 100
+  description = "The EIP bandwidth size. The value for a public loadbalancer ranges from 1 to 1000 Mbit/s. 0 disables the EIP, making the loadbalancer private."
 }
+
 variable "subnet_id" {
   type        = string
-  description = "Subnet where the elastic load balancer will be created."
+  description = "Subnet where the elastic load balancer will be created. "
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,10 +12,10 @@ variable "context_name" {
 variable "bandwidth" {
   type        = number
   default     = 100
-  description = "The EIP bandwidth size. The value for a public loadbalancer ranges from 1 to 1000 Mbit/s. 0 disables the EIP, making the loadbalancer private."
+  description = "The EIP bandwidth size. The value for a public loadbalancer ranges from 1 to 1000 (Mbit/s). 0 disables the EIP, making the loadbalancer private."
 }
 
 variable "subnet_id" {
   type        = string
-  description = "Subnet where the elastic load balancer will be created. "
+  description = "Subnet where the elastic load balancer will be created."
 }


### PR DESCRIPTION
- add count argument to be able to disable EIP for the loadbalancer
- minor refactor to better align code structure with https://github.com/iits-consulting/terraform-opentelekomcloud-dedicated-loadbalancer